### PR TITLE
[INTERNAL] Configurable snapshot clean directory

### DIFF
--- a/jestConfig.js
+++ b/jestConfig.js
@@ -4,6 +4,7 @@ module.exports = {
     'config/**/*.js',
     'reporters/**/*.js',
     'scripts/aggregate-themes/**/*.js',
+    'scripts/wdio/clean-screenshots.js',
   ],
   coverageDirectory: 'tests/jest/reports/coverage',
   coverageReporters: [

--- a/scripts/wdio/clean-screenshots-cli.js
+++ b/scripts/wdio/clean-screenshots-cli.js
@@ -8,7 +8,7 @@ const packageJson = require('../../package.json');
 commander
   .version(packageJson.version)
   .option('--removeReference', 'Whether or not to remove the reference screenshots', false)
-  .option('--snapshotDirectory', 'The directory that clean should check for snapshots folders')
+  .option('--snapshotDirectory [string]', 'The directory that clean should check for snapshots folders', undefined)
   .parse(process.argv);
 
 const {

--- a/scripts/wdio/clean-screenshots-cli.js
+++ b/scripts/wdio/clean-screenshots-cli.js
@@ -8,10 +8,12 @@ const packageJson = require('../../package.json');
 commander
   .version(packageJson.version)
   .option('--removeReference', 'Whether or not to remove the reference screenshots', false)
+  .option('--snapshotDirectory', 'The directory that clean should check for snapshots folders')
   .parse(process.argv);
 
 const {
   removeReference,
+  snapshotDirectory,
 } = commander;
 
-cleanScreenshots({ removeReference });
+cleanScreenshots({ removeReference, snapshotDirectory });

--- a/scripts/wdio/clean-screenshots.js
+++ b/scripts/wdio/clean-screenshots.js
@@ -8,17 +8,20 @@ const isDirectory = filePath => (fs.existsSync(filePath) && fs.lstatSync(filePat
 const cleanSnapshots = (options) => {
   const {
     removeReference,
+    snapshotDirectory,
   } = options;
 
+  const snapshotRoot = snapshotDirectory ? `${snapshotDirectory}/**` : '**';
+
   const patterns = [
-    `${process.cwd()}/**/__snapshots__/latest`,
-    `${process.cwd()}/**/__snapshots__/diff`,
-    `${process.cwd()}/**/__snapshots__/screen`,
+    `${process.cwd()}/${snapshotRoot}/__snapshots__/latest`,
+    `${process.cwd()}/${snapshotRoot}/__snapshots__/diff`,
+    `${process.cwd()}/${snapshotRoot}/__snapshots__/screen`,
     `${process.cwd()}/errorScreenshots`,
   ];
 
   if (removeReference) {
-    patterns.push(`${process.cwd()}/**/__snapshots__/reference`);
+    patterns.push(`${process.cwd()}/${snapshotRoot}/__snapshots__/reference`);
   }
 
   let screenshotDirectories = [];

--- a/scripts/wdio/wdio-runner-cli.js
+++ b/scripts/wdio/wdio-runner-cli.js
@@ -19,6 +19,7 @@ commander
   .option('--gridUrl [url]', 'The selenium grid url to run tests against', undefined)
   .option('--continueOnFail', 'Pass to continue executing test runs when a run fails', false)
   .option('--updateReference', 'Pass to remove all reference screenshots during screenshot cleanup', false)
+  .option('--snapshotDirectory [string]', 'The directory that clean should check for snapshots folders', undefined)
   .option('--host [number]', '[wdio option] The selenium server port', undefined)
   .option('--port [string]', '[wdio option] The selenium server host address', undefined)
   .option('--baseUrl [path]', '[wdio option] The base URL', undefined)
@@ -40,12 +41,14 @@ const {
   suite,
   spec,
   updateReference,
+  snapshotDirectory,
 } = commander;
 
 const configPath = getWdioConfigPath(config);
 
 cleanScreenshots({
   updateReference,
+  snapshotDirectory,
 });
 
 runner({

--- a/tests/jest/clean-screenshots.test.js
+++ b/tests/jest/clean-screenshots.test.js
@@ -1,0 +1,87 @@
+jest.mock('fs-extra');
+jest.mock('glob');
+
+import fs from 'fs-extra';
+import glob from 'glob';
+import cleanSnapshots from '../../scripts/wdio/clean-screenshots';
+
+describe('cleanSnapshots', () => {
+
+  const originalProcessCwd = process.cwd;
+  beforeAll(() => {
+    process.cwd = jest.fn().mockImplementation(() => './terra-toolkit-boneyard');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    process.cwd = originalProcessCwd;
+  });
+
+  const setupMocks = () => {
+    fs.existsSync.mockReturnValue(true);
+    fs.lstatSync.mockReturnValue({ isDirectory: () => true })
+    glob.sync.mockImplementation((path) => `${path}/test`);
+  }
+
+  describe('searches snapshots', () => {
+    const expectToSearchUnder = (path) => {
+      expect(glob.sync).toHaveBeenCalledWith(`${process.cwd()}/${path}/__snapshots__/latest`);
+      expect(glob.sync).toHaveBeenCalledWith(`${process.cwd()}/${path}/__snapshots__/diff`);
+      expect(glob.sync).toHaveBeenCalledWith(`${process.cwd()}/${path}/__snapshots__/screen`);
+      expect(glob.sync).toHaveBeenCalledWith(`${process.cwd()}/errorScreenshots`);
+      expect(glob.sync).toHaveBeenCalledWith(`${process.cwd()}/${path}/__snapshots__/reference`);
+    }
+
+    it('under cwd when snapshot directory is undefined', () => {
+      setupMocks();
+      cleanSnapshots({ removeReference: true });
+      expectToSearchUnder('**');
+    });
+
+    it.each`
+      snapshotDirectory                   | expectedSearchPath
+      ${""}                               | ${'**'}
+      ${'snapshotDirectory'}              | ${'snapshotDirectory/**'}
+      ${'snapshotDirectory/subDirectory'} | ${'snapshotDirectory/subDirectory/**'}`(
+      'under $expectedSearchPath when snapshot directory is $snapshotDirectory',
+      ({ snapshotDirectory, expectedSearchPath }) => {
+        setupMocks();
+        cleanSnapshots({ snapshotDirectory, removeReference: true });
+        expectToSearchUnder(expectedSearchPath);
+      },
+    );
+  });
+
+  describe('deletes snapshots', () => {
+    const expectToDeleteUnder = (path) => {
+      expect(fs.removeSync).toHaveBeenCalledWith(`${process.cwd()}/${path}/__snapshots__/latest/test`);
+      expect(fs.removeSync).toHaveBeenCalledWith(`${process.cwd()}/${path}/__snapshots__/diff/test`);
+      expect(fs.removeSync).toHaveBeenCalledWith(`${process.cwd()}/${path}/__snapshots__/screen/test`);
+      expect(fs.removeSync).toHaveBeenCalledWith(`${process.cwd()}/errorScreenshots/test`);
+      expect(fs.removeSync).toHaveBeenCalledWith(`${process.cwd()}/${path}/__snapshots__/reference/test`);
+    };
+
+    it('under cwd when snapshot directory is undefined', () => {
+      setupMocks();
+      cleanSnapshots({ removeReference: true });
+      expectToDeleteUnder('**');
+    });
+
+    it.each`
+      snapshotDirectory                   | expectedDeletePath
+      ${""}                               | ${'**'}
+      ${'snapshotDirectory'}              | ${'snapshotDirectory/**'}
+      ${'snapshotDirectory/subDirectory'} | ${'snapshotDirectory/subDirectory/**'}`(
+      'under $expectedDeletePath when snapshot directory is $snapshotDirectory',
+      ({ snapshotDirectory, expectedDeletePath }) => {
+        setupMocks();
+        cleanSnapshots({ snapshotDirectory, removeReference: true });
+        expectToDeleteUnder(expectedDeletePath);
+      },
+    );
+  })
+
+});

--- a/tests/jest/clean-screenshots.test.js
+++ b/tests/jest/clean-screenshots.test.js
@@ -1,12 +1,11 @@
-jest.mock('fs-extra');
-jest.mock('glob');
-
 import fs from 'fs-extra';
 import glob from 'glob';
 import cleanSnapshots from '../../scripts/wdio/clean-screenshots';
 
-describe('cleanSnapshots', () => {
+jest.mock('fs-extra');
+jest.mock('glob');
 
+describe('cleanSnapshots', () => {
   const originalProcessCwd = process.cwd;
   beforeAll(() => {
     process.cwd = jest.fn().mockImplementation(() => './terra-toolkit-boneyard');
@@ -22,9 +21,9 @@ describe('cleanSnapshots', () => {
 
   const setupMocks = () => {
     fs.existsSync.mockReturnValue(true);
-    fs.lstatSync.mockReturnValue({ isDirectory: () => true })
+    fs.lstatSync.mockReturnValue({ isDirectory: () => true });
     glob.sync.mockImplementation((path) => `${path}/test`);
-  }
+  };
 
   describe('searches snapshots', () => {
     const expectToSearchUnder = (path) => {
@@ -33,7 +32,7 @@ describe('cleanSnapshots', () => {
       expect(glob.sync).toHaveBeenCalledWith(`${process.cwd()}/${path}/__snapshots__/screen`);
       expect(glob.sync).toHaveBeenCalledWith(`${process.cwd()}/errorScreenshots`);
       expect(glob.sync).toHaveBeenCalledWith(`${process.cwd()}/${path}/__snapshots__/reference`);
-    }
+    };
 
     it('under cwd when snapshot directory is undefined', () => {
       setupMocks();
@@ -43,16 +42,16 @@ describe('cleanSnapshots', () => {
 
     it.each`
       snapshotDirectory                   | expectedSearchPath
-      ${""}                               | ${'**'}
+      ${''}                               | ${'**'}
       ${'snapshotDirectory'}              | ${'snapshotDirectory/**'}
       ${'snapshotDirectory/subDirectory'} | ${'snapshotDirectory/subDirectory/**'}`(
-      'under $expectedSearchPath when snapshot directory is $snapshotDirectory',
-      ({ snapshotDirectory, expectedSearchPath }) => {
-        setupMocks();
-        cleanSnapshots({ snapshotDirectory, removeReference: true });
-        expectToSearchUnder(expectedSearchPath);
-      },
-    );
+  'under $expectedSearchPath when snapshot directory is $snapshotDirectory',
+  ({ snapshotDirectory, expectedSearchPath }) => {
+    setupMocks();
+    cleanSnapshots({ snapshotDirectory, removeReference: true });
+    expectToSearchUnder(expectedSearchPath);
+  },
+);
   });
 
   describe('deletes snapshots', () => {
@@ -72,16 +71,15 @@ describe('cleanSnapshots', () => {
 
     it.each`
       snapshotDirectory                   | expectedDeletePath
-      ${""}                               | ${'**'}
+      ${''}                               | ${'**'}
       ${'snapshotDirectory'}              | ${'snapshotDirectory/**'}
       ${'snapshotDirectory/subDirectory'} | ${'snapshotDirectory/subDirectory/**'}`(
-      'under $expectedDeletePath when snapshot directory is $snapshotDirectory',
-      ({ snapshotDirectory, expectedDeletePath }) => {
-        setupMocks();
-        cleanSnapshots({ snapshotDirectory, removeReference: true });
-        expectToDeleteUnder(expectedDeletePath);
-      },
-    );
-  })
-
+  'under $expectedDeletePath when snapshot directory is $snapshotDirectory',
+  ({ snapshotDirectory, expectedDeletePath }) => {
+    setupMocks();
+    cleanSnapshots({ snapshotDirectory, removeReference: true });
+    expectToDeleteUnder(expectedDeletePath);
+  },
+);
+  });
 });


### PR DESCRIPTION
Configurable snapshot directory to clean.

Current clean pattern is infinite deep, and will look for snapshot folders in node_modules as well. By reducing the folder tree the clean takes much less time